### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/studentprojects/README.md
+++ b/studentprojects/README.md
@@ -1,16 +1,16 @@
-#Student Projects
+# Student Projects
 
 Student projects are being collected via pull request to a [separate repository](https://github.com/barbagroup/AeroPython-studentprojects).
 Instructor feedback is provided via comments on the pull request, and the best projects are merged.
 We provide links here to some sample projets from each year.
 
-###Spring 2014
+### Spring 2014
 
 * [Limitations of Inviscid Panel Method](http://nbviewer.ipython.org/github/LTChaseJohnson/MAE6226/blob/master/final%20project.ipynb), Chase Johnson
 * [Pterosaur wings: effect of the wing-tip twist on center-of-pressure location](http://nbviewer.ipython.org/github/colinparker/Pterosaur/blob/master/parker_pterosaur.ipynb) (following Palmer & Dyke, 2012; using XFLR)
 * [Boundary Layer Correction in Panel Methods](http://nbviewer.ipython.org/github/iancarr/AeroHydro/blob/master/final-project/BoundaryLayerCorrection.ipynb), Ian Carr.
 * [Stokes Flow with a Boundary Element Method](http://nbviewer.ipython.org/github/arm6226/mae6226/blob/master/project/MAE6226%20Project.ipynb), Abhilash Malipeddi
 
-###Spring 2015
+### Spring 2015
 
 Coming soon!


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
